### PR TITLE
Merge in govcms8_uikit under templates

### DIFF
--- a/assets/scss/uikit/accordion/accordion.twig
+++ b/assets/scss/uikit/accordion/accordion.twig
@@ -1,6 +1,6 @@
 <h3>Single accordion open fast by default</h3>
 {%
-  include '@govcms8_uikit/templates/accordion/accordion.twig' with {
+  include '@govcms8_uikit/accordion/accordion.twig' with {
   id: id_1,
   title: title_1,
   body: body_1,
@@ -17,7 +17,7 @@
 
 <div class="accordion-group">
   {%
-    include '@govcms8_uikit/templates/accordion/accordion.twig' with {
+    include '@govcms8_uikit/accordion/accordion.twig' with {
     id: id_2,
     title: title_2,
     body: body_2,
@@ -26,7 +26,7 @@
   } only
   %}
   {%
-    include '@govcms8_uikit/templates/accordion/accordion.twig' with {
+    include '@govcms8_uikit/accordion/accordion.twig' with {
     id: id_3,
     title: title_3,
     body: body_3,
@@ -35,7 +35,7 @@
   } only
   %}
   {%
-    include '@govcms8_uikit/templates/accordion/accordion.twig' with {
+    include '@govcms8_uikit/accordion/accordion.twig' with {
     id: id_4,
     title: title_4,
     body: body_4,

--- a/assets/scss/uikit/breadcrumb/breadcrumb.twig
+++ b/assets/scss/uikit/breadcrumb/breadcrumb.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/breadcrumb/breadcrumb.twig' %}
+{% include '@govcms8_uikit/breadcrumb/breadcrumb.twig' %}

--- a/assets/scss/uikit/cta-link/cta_link.twig
+++ b/assets/scss/uikit/cta-link/cta_link.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/cta-link/cta_link.twig' %}
+{% include '@govcms8_uikit/cta-link/cta_link.twig' %}

--- a/assets/scss/uikit/header/header.twig
+++ b/assets/scss/uikit/header/header.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/header/header.twig' %}
+{% include '@govcms8_uikit/header/header.twig' %}

--- a/assets/scss/uikit/inpage-nav/inpage_nav.twig
+++ b/assets/scss/uikit/inpage-nav/inpage_nav.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/inpage-nav/inpage_nav.twig' %}
+{% include '@govcms8_uikit/inpage-nav/inpage_nav.twig' %}

--- a/assets/scss/uikit/keyword-list/keyword_list.twig
+++ b/assets/scss/uikit/keyword-list/keyword_list.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/keyword-list/keyword_list.twig' %}
+{% include '@govcms8_uikit/keyword-list/keyword_list.twig' %}

--- a/assets/scss/uikit/link-list/link_list.twig
+++ b/assets/scss/uikit/link-list/link_list.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/link-list/link_list.twig' %}
+{% include '@govcms8_uikit/link-list/link_list.twig' %}

--- a/assets/scss/uikit/page-alerts/page_alerts.twig
+++ b/assets/scss/uikit/page-alerts/page_alerts.twig
@@ -1,1 +1,1 @@
-{% extends '@govcms8_uikit/templates/page-alerts/page_alerts.twig' %}
+{% extends '@govcms8_uikit/page-alerts/page_alerts.twig' %}

--- a/assets/scss/uikit/progress-indicator/progress_indicator.twig
+++ b/assets/scss/uikit/progress-indicator/progress_indicator.twig
@@ -1,1 +1,1 @@
-{% include '@govcms8_uikit/templates/progress-indicator/progress_indicator.twig'%}
+{% include '@govcms8_uikit/progress-indicator/progress_indicator.twig'%}

--- a/assets/scss/uikit/tags/tags.twig
+++ b/assets/scss/uikit/tags/tags.twig
@@ -1,1 +1,1 @@
-{% extends '@govcms8_uikit/templates/tags/tags.twig' %}
+{% extends '@govcms8_uikit/tags/tags.twig' %}

--- a/govcms8_uikit_starter.info.yml
+++ b/govcms8_uikit_starter.info.yml
@@ -1,7 +1,6 @@
 name: 'GovCMS 8 UI-Kit Starter'
 description: 'Starter theme with basic implementation of GovCMS 8 UI-Kit. Cloning this theme is recommended, if you need more customization.'
 
-base theme: govcms8_uikit
 core: 8.x
 type: theme
 libraries:
@@ -20,3 +19,7 @@ regions:
   postscript_3: 'Postscript 3'
   postscript_4: 'Postscript 4'
   legal: 'Legal'
+component-libraries:
+  govcms8_uikit:
+    paths:
+      - templates/uikit

--- a/kss-config.json
+++ b/kss-config.json
@@ -21,6 +21,6 @@
   ],
 
   "namespace": [
-    "govcms8_uikit:../govcms8_uikit"
+    "govcms8_uikit:templates/uikit"
   ]
 }

--- a/styleguide/item-ui-kit-accordion.html
+++ b/styleguide/item-ui-kit-accordion.html
@@ -430,7 +430,7 @@
                   </summary>
         <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;h3&gt;Single accordion open fast by default&lt;/h3&gt;
 {%
-  include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+  include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
   id: id_1,
   title: title_1,
   body: body_1,
@@ -447,7 +447,7 @@
 
 &lt;div class=&quot;accordion-group&quot;&gt;
   {%
-    include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+    include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
     id: id_2,
     title: title_2,
     body: body_2,
@@ -456,7 +456,7 @@
   } only
   %}
   {%
-    include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+    include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
     id: id_3,
     title: title_3,
     body: body_3,
@@ -465,7 +465,7 @@
   } only
   %}
   {%
-    include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+    include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
     id: id_4,
     title: title_4,
     body: body_4,

--- a/styleguide/item-ui-kit-breadcrumb.html
+++ b/styleguide/item-ui-kit-breadcrumb.html
@@ -240,7 +240,7 @@
         <summary>
                       Markup: <code>uikit/breadcrumb/breadcrumb.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/breadcrumb/breadcrumb.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/breadcrumb/breadcrumb.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-cta-link.html
+++ b/styleguide/item-ui-kit-cta-link.html
@@ -164,7 +164,7 @@
         <summary>
                       Markup: <code>uikit/cta-link/cta_link.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/cta-link/cta_link.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/cta-link/cta_link.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-header.html
+++ b/styleguide/item-ui-kit-header.html
@@ -248,7 +248,7 @@
         <summary>
                       Markup: <code>uikit/header/header.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/header/header.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/header/header.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-inpage-nav.html
+++ b/styleguide/item-ui-kit-inpage-nav.html
@@ -248,7 +248,7 @@
         <summary>
                       Markup: <code>uikit/inpage-nav/inpage_nav.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/inpage-nav/inpage_nav.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/inpage-nav/inpage_nav.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-keyword-list.html
+++ b/styleguide/item-ui-kit-keyword-list.html
@@ -272,7 +272,7 @@
         <summary>
                       Markup: <code>uikit/keyword-list/keyword_list.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/keyword-list/keyword_list.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/keyword-list/keyword_list.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-link-list.html
+++ b/styleguide/item-ui-kit-link-list.html
@@ -352,7 +352,7 @@
         <summary>
                       Markup: <code>uikit/link-list/link_list.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/link-list/link_list.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/link-list/link_list.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-page-alerts.html
+++ b/styleguide/item-ui-kit-page-alerts.html
@@ -508,7 +508,7 @@
         <summary>
                       Markup: <code>uikit/page-alerts/page_alerts.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/templates/page-alerts/page_alerts.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/page-alerts/page_alerts.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-progress-indicator.html
+++ b/styleguide/item-ui-kit-progress-indicator.html
@@ -288,7 +288,7 @@
         <summary>
                       Markup: <code>uikit/progress-indicator/progress_indicator.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/progress-indicator/progress_indicator.twig&#039;%}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/progress-indicator/progress_indicator.twig&#039;%}
 </code></pre>
       </details>
       

--- a/styleguide/item-ui-kit-tags.html
+++ b/styleguide/item-ui-kit-tags.html
@@ -204,7 +204,7 @@
         <summary>
                       Markup: <code>uikit/tags/tags.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/templates/tags/tags.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/tags/tags.twig&#039; %}
 </code></pre>
       </details>
       

--- a/styleguide/section-ui-kit.html
+++ b/styleguide/section-ui-kit.html
@@ -547,7 +547,7 @@
                   </summary>
         <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;h3&gt;Single accordion open fast by default&lt;/h3&gt;
 {%
-  include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+  include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
   id: id_1,
   title: title_1,
   body: body_1,
@@ -564,7 +564,7 @@
 
 &lt;div class=&quot;accordion-group&quot;&gt;
   {%
-    include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+    include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
     id: id_2,
     title: title_2,
     body: body_2,
@@ -573,7 +573,7 @@
   } only
   %}
   {%
-    include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+    include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
     id: id_3,
     title: title_3,
     body: body_3,
@@ -582,7 +582,7 @@
   } only
   %}
   {%
-    include &#039;@govcms8_uikit/templates/accordion/accordion.twig&#039; with {
+    include &#039;@govcms8_uikit/accordion/accordion.twig&#039; with {
     id: id_4,
     title: title_4,
     body: body_4,
@@ -824,7 +824,7 @@
         <summary>
                       Markup: <code>uikit/breadcrumb/breadcrumb.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/breadcrumb/breadcrumb.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/breadcrumb/breadcrumb.twig&#039; %}
 </code></pre>
       </details>
       
@@ -1450,7 +1450,7 @@
         <summary>
                       Markup: <code>uikit/cta-link/cta_link.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/cta-link/cta_link.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/cta-link/cta_link.twig&#039; %}
 </code></pre>
       </details>
       
@@ -1692,7 +1692,7 @@
         <summary>
                       Markup: <code>uikit/header/header.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/header/header.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/header/header.twig&#039; %}
 </code></pre>
       </details>
       
@@ -1934,7 +1934,7 @@
         <summary>
                       Markup: <code>uikit/inpage-nav/inpage_nav.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/inpage-nav/inpage_nav.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/inpage-nav/inpage_nav.twig&#039; %}
 </code></pre>
       </details>
       
@@ -2200,7 +2200,7 @@
         <summary>
                       Markup: <code>uikit/keyword-list/keyword_list.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/keyword-list/keyword_list.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/keyword-list/keyword_list.twig&#039; %}
 </code></pre>
       </details>
       
@@ -2546,7 +2546,7 @@
         <summary>
                       Markup: <code>uikit/link-list/link_list.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/link-list/link_list.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/link-list/link_list.twig&#039; %}
 </code></pre>
       </details>
       
@@ -3048,7 +3048,7 @@
         <summary>
                       Markup: <code>uikit/page-alerts/page_alerts.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/templates/page-alerts/page_alerts.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/page-alerts/page_alerts.twig&#039; %}
 </code></pre>
       </details>
       
@@ -3330,7 +3330,7 @@
         <summary>
                       Markup: <code>uikit/progress-indicator/progress_indicator.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/templates/progress-indicator/progress_indicator.twig&#039;%}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% include &#039;@govcms8_uikit/progress-indicator/progress_indicator.twig&#039;%}
 </code></pre>
       </details>
       
@@ -3528,7 +3528,7 @@
         <summary>
                       Markup: <code>uikit/tags/tags.twig</code>
                   </summary>
-        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/templates/tags/tags.twig&#039; %}
+        <pre class="prettyprint linenums lang-html"><code data-language="html">{% extends &#039;@govcms8_uikit/tags/tags.twig&#039; %}
 </code></pre>
       </details>
       

--- a/templates/uikit/accordion/accordion.twig
+++ b/templates/uikit/accordion/accordion.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Component for an accordion item.
+ *
+ * Variables:
+ * - accordion_item_id: [number] Serve to map Accordion title to body.
+ * - title: [string] Heading of the accordion item.
+ * - body: [string] Text of the item.
+ * - speed: [string] The speed of opening the accordion. Defaults to 'fast'.
+ * - orientation: [string] The initial state of the item.  Defaults to 'open'
+ */
+#}
+{% block accordion %}
+
+  <section class="au-accordion">
+
+    {% if orientation == 'open' %}
+      <a href="#accordion-{{ id }}" class="au-accordion__title"
+         aria-expanded="true" aria-selected="true" aria-controls="accordion-{{ id }}" role="tab" onclick="return AU.accordion.Toggle( this{{ speed }} )">{{ title }}</a>
+
+      <div class="au-accordion__body" aria-hidden="false" id="accordion-{{ id }}">
+        <div class="au-accordion__body-wrapper">{{ body }}</div>
+      </div>
+
+    {% else %}
+
+      <a href="#accordion-{{ id }}" class="au-accordion__title au-accordion--closed"
+         aria-expanded="false" aria-selected="false" aria-controls="accordion-{{ id }}" role="tab" onclick="return AU.accordion.Toggle( this{{ speed }} )">{{ title }}</a>
+
+      <div class="au-accordion__body au-accordion--closed" aria-hidden="true" id="accordion-{{ id }}">
+        <div class="au-accordion__body-wrapper">{{ body }}</div>
+      </div>
+
+    {% endif %}
+
+  </section>
+
+{% endblock %}

--- a/templates/uikit/breadcrumb/breadcrumb.twig
+++ b/templates/uikit/breadcrumb/breadcrumb.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Component for a breadcrumb navigation.
+ *
+ * Variables:
+ * - heading: [string] Accessible heading.
+ * - breadcrumb: [array] The breadcrumb items. Each item is an object containing:
+ *   - text: [string] Text of the item.
+ *   - url: [string] URL of the item (optional).
+ */
+#}
+<nav class="au-breadcrumbs" role="navigation" aria-label="breadcrumb">
+  <h2 id="breadcrumb" class="visually-hidden">{{ heading|default('You are here') }}</h2>
+  <ol class="au-link-list au-link-list--inline">
+    {% for item in items %}
+      <li>
+        {% if item.url %}
+          <a href="{{ item.url }}">{{ item.text }}</a>
+        {% else %}
+          {{ item.text }}
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ol>
+</nav>

--- a/templates/uikit/button/button.twig
+++ b/templates/uikit/button/button.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Component for a button.
+ *
+ * Variables:
+ * - content: [string] Text on the button.
+ */
+#}
+{% set classes=[
+  'au-btn',
+]
+%}
+{% block button %}
+  <button class="{{classes}}">{{ content }}</button>
+{% endblock %}

--- a/templates/uikit/cta-link/cta_link.twig
+++ b/templates/uikit/cta-link/cta_link.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Component for a click to action (CTA) link.
+ *
+ * Variables:
+ * - text: [string] Text of the item.
+ * - url: [string] URL of the item.
+ */
+#}
+{% set classes = [
+  'au-cta-link',
+]
+%}
+{% block cta_link %}
+  <a class="{{ classes }}" href="{{ url }}">{{ text }}</a>
+{% endblock %}

--- a/templates/uikit/header/header.twig
+++ b/templates/uikit/header/header.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Component for a header area.
+ *
+ * Variables:
+ * - modifier_class: [string] Ussed by KSS-node for variations.
+ * - content: [string] Text of the heading.
+ */
+#}
+{% block header %}
+  <header class="au-header" role="banner">
+    <h1 class="au-header-heading {{ modifier_class }}">{{ content }}</h1>
+  </header>
+{% endblock %}
+

--- a/templates/uikit/inpage-nav/inpage_nav.twig
+++ b/templates/uikit/inpage-nav/inpage_nav.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Component for an inpage navigation.
+ *
+ * Variables:
+ * - item: [array] The inpage navigation items. Each item is an object containing:
+ *   - text: [string] Text of the item.
+ *   - url: [string] URL of the item.
+ */
+#}
+<nav class="au-inpage-nav-links">
+  <h2 class="au-inpage-nav-links__heading">Contents</h2>
+  <ul class="au-link-list">
+    {% for item in items %}
+      <li>
+        <a href="{{ item.url }}">{{ item.text }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+</nav>
+
+

--- a/templates/uikit/keyword-list/keyword_list.twig
+++ b/templates/uikit/keyword-list/keyword_list.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Component for keyword list.
+ *
+ * Variables:
+ * - item: [array] The keyword list items. Each item is an object containing:
+ *   - text: [string] Text of the item.
+ *   - url: [string] URL of the item (optional).
+ *   - small: [string] Small writing above the main text of the item.
+ */
+#}
+<ul class="au-keyword-list au-link-list">
+  {% for item in items %}
+    <li>
+      {% if item.url %}
+        <a href="{{ item.url }}">
+          <small class="au-keyword-list__small">{{ item.small }}</small>
+          {{ item.text }}
+        </a>
+      {% else %}
+        <small class="au-keyword-list__small">{{ item.small }}</small>
+        {{ item.text }}
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>

--- a/templates/uikit/link-list/link_list.twig
+++ b/templates/uikit/link-list/link_list.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Component for list of links.
+ *
+ * Variables:
+ * - modifier_class: [string] Ussed by KSS-node for variations.
+ * - item: [array] The link list items. Each item is an object containing:
+ *   - text: [string] Text of the item.
+ *   - url: [string] URL of the item.
+ */
+#}
+<ul class="au-link-list {{ modifier_class  }}">
+  {% for item in items %}
+    <li>
+      <a href="{{ item.url }}">
+        {{ item.text }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>

--- a/templates/uikit/page-alerts/page_alerts.twig
+++ b/templates/uikit/page-alerts/page_alerts.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * @file
+ * Component for messages.
+ *
+ * Variables:
+ * - modifier_class: [string] Classes to modify the default component styling.
+ * - heading: [string] Accessible heading.
+ * - attributes: [string] HTML attributes for the wrapping element.
+ * - messages: [array] The messages. Each item in the array is a string.
+ */
+#}
+<div class="au-body au-page-alerts {{ modifier_class }}" {% if heading %}aria-label="{{ heading }}"{% endif %} {{ attributes }} role="alert">
+  {% block heading %}
+    {% if heading %}
+      <h3 class="visually-hidden">{{ heading }}</h3>
+    {% endif %}
+  {% endblock heading %}
+
+  {% block content %}
+    {% if messages|length > 1 %}
+      <ul>
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      {{ messages|first }}
+    {% endif %}
+  {% endblock content %}
+</div>

--- a/templates/uikit/progress-indicator/progress_indicator.twig
+++ b/templates/uikit/progress-indicator/progress_indicator.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Component for progress indicator.
+ *
+ * Variables:
+ * - item: [array] The progress indicator items. Each item is an object containing:
+ *   - text: [string] Text of the item.
+ *   - url: [string] URL of the item.
+ *   - status: [string] Status of the item.
+ */
+#}
+<ul class="au-progress-indicator">
+  {% for item in items %}
+    {% set link_classes = [
+      'au-progress-indicator__link--' ~ item.status|lower,
+    ]
+    %}
+    <li>
+      <a href="{{ item.url }}" class="au-progress-indicator__link {{ link_classes }}">
+        <span class="au-progress-indicator__status">{{ item.status }}</span>
+        {{ item.text }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>

--- a/templates/uikit/tags/tags.twig
+++ b/templates/uikit/tags/tags.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Component for tags.
+ *
+ * Variables:
+ * - item: [array] The tags items. Each item is an object containing:
+ *   - content: [string] Text of the item.
+ */
+#}
+{% block tags %}
+  <ul class="au-tags">
+    {% for item in items %}
+      <li>{{ item.content }}</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/templates/uikit/text-inputs/input.twig
+++ b/templates/uikit/text-inputs/input.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+{% block input %}
+  <input {{ attributes.addClass(classes|default('au-text-input')) }} />
+{% endblock %}

--- a/templates/uikit/text-inputs/textarea.twig
+++ b/templates/uikit/text-inputs/textarea.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Theme override for a 'textarea' #type form element.
+ *
+ * Available variables
+ * - wrapper_attributes: A list of HTML attributes for the wrapper element.
+ * - attributes: A list of HTML attributes for the <textarea> element.
+ * - resizable: An indicator for whether the textarea is resizable.
+ * - required: An indicator for whether the textarea is required.
+ * - value: The textarea content.
+ *
+ * @see template_preprocess_textarea()
+ */
+#}
+{% block textarea %}
+  <textarea class="au-text-input au-text-input--block">{{ value }}</textarea>
+{% endblock %}


### PR DESCRIPTION
This PR uses the components module to add the ui-kit templates (from https://github.com/govCMS/govcms8_uikit) to the theme.

There will be a matching PR to GovCMS8 to modify the govcms.info.yml and composer.json accordingly