### PR TITLE
[GCMSLG-116] Remove main / nav / banner / content info roles.

### DIFF
--- a/templates/block/block--local-tasks-block.html.twig
+++ b/templates/block/block--local-tasks-block.html.twig
@@ -14,7 +14,7 @@
    ]
   %}
   {% if content %}
-    <nav{{ attributes.addClass(classes) }} role="navigation" aria-label="{{ 'Tabs'|t }}">
+    <nav{{ attributes.addClass(classes) }} aria-label="{{ 'Tabs'|t }}">
       <div class="container">
         {{ content }}
       </div>

--- a/templates/block/block--system-menu-block.html.twig
+++ b/templates/block/block--system-menu-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for a menu block.
+ * Theme override for a menu block.
  *
  * Available variables:
  * - plugin_id: The ID of the block implementation.
@@ -29,12 +29,10 @@
  * to or skip the links.
  * See http://juicystudio.com/article/screen-readers-display-none.php and
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
- *
- * @ingroup themeable
  */
 #}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
+<nav aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/inc/page_footer.html.twig
+++ b/templates/inc/page_footer.html.twig
@@ -28,7 +28,7 @@
     {% set count = count + 1 %}
   {% endif %}
 
-<footer{{ footer_attributes.addClass(footer_classes) }} role="contentinfo">
+<footer{{ footer_attributes.addClass(footer_classes) }}>
   <div class="container">
 
     {% if count > 0 %}

--- a/templates/inc/page_header.html.twig
+++ b/templates/inc/page_header.html.twig
@@ -10,7 +10,7 @@
 ]
 %}
 
-<header{{ header_attributes.addClass(header_classes) }} role="banner">
+<header{{ header_attributes.addClass(header_classes) }}>
   <div class="container">
     <div class="row header--vertical-align">
 

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -82,7 +82,7 @@
   {% endif %}
 
   {# Main content area of the page. #}
-  <main role="main">
+  <main>
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
 
     {# Template for panelized node pages. #}
@@ -102,7 +102,7 @@
               {{ page.content }}
             </div>{# /.layout-content #}
 
-            <aside class="layout-sidebar col-sm-4" role="complementary">
+            <aside class="layout-sidebar col-sm-4">
               {{ page.sidebar }}
             </aside>
           </div>

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -30,7 +30,7 @@
  */
 #}
 {% if items %}
-  <nav class="pager" role="navigation" aria-labelledby="pagination-heading">
+  <nav class="pager" aria-labelledby="pagination-heading">
     <h4 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h4>
     <ul class="pager__items js-pager__items au-link-list au-link-list--inline">
       {# Print first item if we are not on the first page. #}

--- a/templates/uikit/breadcrumb/breadcrumb.twig
+++ b/templates/uikit/breadcrumb/breadcrumb.twig
@@ -10,7 +10,7 @@
  *   - url: [string] URL of the item (optional).
  */
 #}
-<nav class="au-breadcrumbs" role="navigation" aria-label="breadcrumb">
+<nav class="au-breadcrumbs" aria-label="breadcrumb">
   <h2 id="breadcrumb" class="visually-hidden">{{ heading|default('You are here') }}</h2>
   <ol class="au-link-list au-link-list--inline">
     {% for item in items %}

--- a/templates/uikit/header/header.twig
+++ b/templates/uikit/header/header.twig
@@ -9,7 +9,7 @@
  */
 #}
 {% block header %}
-  <header class="au-header" role="banner">
+  <header class="au-header">
     <h1 class="au-header-heading {{ modifier_class }}">{{ content }}</h1>
   </header>
 {% endblock %}

--- a/templates/views/views-mini-pager.html.twig
+++ b/templates/views/views-mini-pager.html.twig
@@ -10,7 +10,7 @@
  */
 #}
 {% if items.previous or items.next %}
-  <nav class="pager" role="navigation" aria-labelledby="pagination-heading">
+  <nav class="pager" aria-labelledby="pagination-heading">
     <h4 class="pager__heading visually-hidden">{{ 'Pagination'|t }}</h4>
     <ul class="pager__items js-pager__items au-link-list au-link-list--inline">
       {% if items.previous %}


### PR DESCRIPTION
* Removed unnecessary roles from landmark elements.
* main menu block now generic to allow for removal of navigation role from header and footer menus.