### PR TITLE
Added paragraph class name based on paragraph id

### DIFF
--- a/govcms8_uikit_starter.theme
+++ b/govcms8_uikit_starter.theme
@@ -140,6 +140,14 @@ function govcms8_uikit_starter_preprocess_page(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function govcms8_uikit_starter_preprocess_paragraph(array &$variables) {
+  // Add class "paragraph-id-ID" to paragraph wrapper.
+  $variables['attributes']['class'][] = 'paragraph-id-' . $variables['paragraph']->id();
+}
+
+/**
  * Implements hook_form_alter().
  */
 function govcms8_uikit_starter_form_alter(&$form, FormStateInterface $form_state) {


### PR DESCRIPTION
**Changes**

- Adds class "paragraph-id-ID" (e.g. paragraph-id-12) to the paragraph element.

**Testing instructions**

- Clear site cache
- Create a node containing multiple paragraphs.
- Load page and confirm that each paragraph element contains a unique classname in the format  "paragraph-id-ID" (e.g. paragraph-id-12).

**Notes**

- This pull request was created as a solution to issue discussed [here](https://github.com/govCMS/govcms8_uikit_starter/issues/63)