### PR TITLE
Add Card component as extend of Stack.

### DIFF
--- a/assets/scss/components/view_modes/stack/_stack.scss
+++ b/assets/scss/components/view_modes/stack/_stack.scss
@@ -1,40 +1,44 @@
+/*
+* Stacks as Design system Card
+* In the beginning there were no Card, so we created a Stack. Then someone say
+* lets there be a card. We cannot remove the stack layout with markup for backward
+* compatibility. Instead we add card classes through preprocess and extend some
+* other to the original stack markup.
+ */
 .stack {
-  background: $white;
-  box-shadow: 0 0 20px $govcms8-color-shadow;
-  color: $AU-color-foreground-text;
+  // Can be removed once https://github.com/govau/design-system-components/issues/822 is done.
   height: 100%;
-
-  a {
-    color: $AU-color-foreground-action;
-  }
 }
 
 .stack__image {
-  a {
-    display: block;
-  }
-
   img {
     display: block;
     width: 100%;
   }
 }
 
+// Stack title is extended to Card title.
+.stack__title {
+  @extend .au-card__title;
+
+  .au-card--clickable & {
+    a {
+      @extend .au-card--clickable__link;
+    }
+  }
+}
+
+// Stack content is extened to Card inner.
 .stack__content {
-  @include AU-space(padding, 1unit);
+  @extend .au-card__inner;
 
   // All regions has one third unit gap between them.
   *[class^='stack__'] + *[class^='stack__'] {
     @include AU-space(margin-top, .3unit);
   }
-
-  // Title has a full unit gap bellow.
-  h3.stack__title {
-    @include AU-space(margin-bottom, 1unit);
-  }
 }
 
-// Stack looks the same on all backgrounds.
+// Stack/cards looks the same on all backgrounds.
 .au-body--alt,
 .au-body--dark,
 .au-body--dark.au-body--alt,

--- a/css/style.css
+++ b/css/style.css
@@ -1178,6 +1178,124 @@ a.au-btn {
   margin-top: 8px;
   margin-top: 0.5rem; }
 
+/*! @gov.au/card v0.3.1 */
+.au-card {
+  display: block;
+  width: 100%;
+  border-radius: 4px;
+  border: 1px solid lightgray;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  position: relative;
+  background: #ffffff; }
+  .au-card.au-card--shadow {
+    border-radius: 4px;
+    overflow: hidden;
+    -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); }
+    .au-card.au-card--shadow:hover {
+      -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
+              box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3); }
+  .au-card.au-card--clickable:focus-within {
+    outline: 3px solid #9263DE;
+    outline-offset: 2px; }
+  .au-card.au-card--clickable .au-card--clickable__link:after, .au-card.au-card--clickable .stack__title a:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0; }
+  .au-card.au-card--clickable .au-card--clickable__link:focus, .au-card.au-card--clickable .stack__title a:focus {
+    outline: none; }
+  .lt-ie9 .au-card.au-card--clickable .au-card--clickable__link:focus, .lt-ie9 .au-card.au-card--clickable .stack__title a:focus {
+    outline: 3px solid #9263DE;
+    outline-offset: 2px; }
+  .au-card * + .au-card__divider,
+  .au-card * + .au-card__body,
+  .au-card * + .au-card__footer {
+    margin-top: 16px;
+    margin-top: 1rem; }
+  .au-card .au-card__divider {
+    border: lightgray 0.5px solid;
+    margin-bottom: 0; }
+  .au-card .au-card__title, .au-card .stack__title {
+    margin: 0 0 16px 0;
+    margin: 0 0 1rem 0; }
+  .au-card .au-card__header {
+    font-weight: bold;
+    margin: 0;
+    border-bottom: solid 1px lightgray;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    padding: 16px;
+    padding: 1rem; }
+  .au-card .au-card__footer {
+    padding: 16px;
+    padding: 1rem;
+    margin: 0;
+    border-top: solid 1px lightgray;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px; }
+  .au-card .au-card__inner, .au-card .stack__content {
+    padding: 16px;
+    padding: 1rem; }
+  .lt-ie9 .au-card {
+    border: solid 1px gray; }
+  .au-card.au-card--centred, .au-card .au-card--centred {
+    text-align: center; }
+
+a.au-card {
+  color: #313131;
+  cursor: pointer;
+  text-decoration: none; }
+  a.au-card .au-card__title, a.au-card .stack__title {
+    color: #00698f;
+    text-decoration: underline;
+    text-decoration-skip-ink: auto; }
+  a.au-card:hover .au-card__title, a.au-card:hover .stack__title {
+    text-decoration: none;
+    color: #313131; }
+  a.au-card:focus {
+    outline: 3px solid #9263DE;
+    outline-offset: 2px; }
+  a.au-card.au-card--shadow:focus {
+    border-radius: 0; }
+  a.au-card.au-card--shadow:hover {
+    -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3); }
+
+.au-card-list {
+  list-style: none;
+  padding: 0; }
+  .au-card-list:before, .au-card-list:after {
+    content: " ";
+    display: table; }
+  .au-card-list:after {
+    clear: both; }
+  .au-card-list:before {
+    display: none; }
+  .au-card-list li {
+    list-style: none;
+    padding: 0;
+    margin-top: 24px;
+    margin-top: 1.5rem; }
+  .au-card-list.au-card-list--matchheight {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap; }
+    .au-card-list.au-card-list--matchheight li {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex; }
+    .au-card-list.au-card-list--matchheight .au-card {
+      display: block;
+      -webkit-box-orient: vertical;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: column;
+              flex-direction: column; }
+
 /*! @gov.au/control-input v2.2.2 */
 /**
  * Return the right SVG shape for fore- and background
@@ -4231,31 +4349,23 @@ table {
   margin-bottom: 16px;
   margin-bottom: 1rem; }
 
+/*
+* Stacks as Design system Card
+* In the beginning there were no Card, so we created a Stack. Then someone say
+* lets there be a card. We cannot remove the stack layout with markup for backward
+* compatibility. Instead we add card classes through preprocess and extend some
+* other to the original stack markup.
+ */
 .stack {
-  background: #FFFFFF;
-  -webkit-box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
-          box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
-  color: #313131;
   height: 100%; }
-  .stack a {
-    color: #00698f; }
-
-.stack__image a {
-  display: block; }
 
 .stack__image img {
   display: block;
   width: 100%; }
 
-.stack__content {
-  padding: 16px;
-  padding: 1rem; }
-  .stack__content *[class^='stack__'] + *[class^='stack__'] {
-    margin-top: 5px;
-    margin-top: 0.3rem; }
-  .stack__content h3.stack__title {
-    margin-bottom: 16px;
-    margin-bottom: 1rem; }
+.stack__content *[class^='stack__'] + *[class^='stack__'] {
+  margin-top: 5px;
+  margin-top: 0.3rem; }
 
 .au-body--alt .stack,
 .au-body--dark .stack,

--- a/govcms8_uikit_starter.theme
+++ b/govcms8_uikit_starter.theme
@@ -292,3 +292,31 @@ function govcms8_uikit_starter_theme_find_active_link(&$links, $path) {
     }
   }
 }
+
+/**
+ * Implements template_preprocess_layout().
+ */
+function govcms8_uikit_starter_preprocess_layout(&$variables) {
+  /** @var \Drupal\Core\Layout\LayoutDefinition $layout */
+  $layout = $variables['layout'];
+  if (in_array($layout->id(), [
+    'stack_detail',
+    'stack_simple',
+  ])) {
+    // Add Design System Card classes to the stack layout.
+    $variables['attributes']['class'][] = 'au-card';
+    $variables['attributes']['class'][] = 'au-body';
+    $variables['attributes']['class'][] = 'au-card--shadow';
+
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    $entity = $variables['content']['#entity'];
+
+    // Only if Item url field is not empty or Display suite title link is set.
+    if (($entity->hasField('field_item_url') && !$entity->get('field_item_url')->isEmpty())
+        || !empty($variables['content']['title']['node_title'][0][0]['#context']['is_link'])
+    ) {
+      // Add au-card--clickable class to Card.
+      $variables['attributes']['class'][] = 'au-card--clickable';
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,18 @@
         "@gov.au/pancake-sass": "~2"
       }
     },
+    "@gov.au/card": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gov.au/card/-/card-0.3.1.tgz",
+      "integrity": "sha512-hQONukqYF8ZnaQi8C2MWn+W8fv0F9iyYHySKYnjuklgA7wFjn+WqdYSkSKYKT21Bx60Rlt+wCt9V0XLPrPl4nQ==",
+      "requires": {
+        "@gov.au/core": "^3.0.0",
+        "@gov.au/pancake": "~1",
+        "@gov.au/pancake-json": "~1",
+        "@gov.au/pancake-react": "~1",
+        "@gov.au/pancake-sass": "~2"
+      }
+    },
     "@gov.au/control-input": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@gov.au/control-input/-/control-input-2.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@gov.au/breadcrumbs": "^3.0.3",
     "@gov.au/buttons": "^3.0.5",
     "@gov.au/callout": "^3.0.1",
+    "@gov.au/card": "^0.3.1",
     "@gov.au/control-input": "^2.2.2",
     "@gov.au/core": "^3.2.0",
     "@gov.au/cta-link": "^2.1.5",


### PR DESCRIPTION
PR for #92 

There is no need to udpate the markup in foundations layout.
The required classes were added using preprocess/sass extends, including dynamic check for clickable link.

Extra notes
- Check for clickable link is done for Display suite title field – this will need to be updated once we switch to Layout builder.
- Almost all previous Stack styling was removed and replaced by Card classes.